### PR TITLE
Align integration with ZEWA i-SAFE API

### DIFF
--- a/custom_components/judo_leakguard/README.md
+++ b/custom_components/judo_leakguard/README.md
@@ -13,22 +13,86 @@
 - HTTPS optional (bei Self-Signed „Verify SSL“ deaktivieren)
 - „Send data as query“ umschalten, falls deine Firmware GET (mit `?data=`) statt POST erwartet.
 
-## Entities (Auszug)
+## Entitäten
 
-- **Switches**: Ventil öffnen/schließen (5100/5200), Sleep-Modus (5400/5500), Urlaubsmodus (5700/5800)
-- **Buttons**: Meldungen zurücksetzen (6300), Mikroleckageprüfung starten (5C00), Lernmodus starten (5D00)
-- **Numbers**: Sleep-Dauer (53/66), Abwesenheits-Grenzwerte für Durchfluss/Volumen/Zeit (5F/5E)
-- **Selects**: Urlaubsmodus-Typ (56), Mikro-Leckage-Betrieb (5B/65)
-- **Sensoren**: Leitungsdruck, Durchfluss, Geräte-Temperatur, Batteriestand, Gesamtverbrauch (2800), Gerätezeit (5900), Lernmodus-Status & Restwassermenge (6400), Abwesenheitslimits (5E00), Installationsdatum (0E00) uvm.
+### Switches
+
+| Entity-ID | Beschreibung | API |
+| --- | --- | --- |
+| `switch.<gerät>_valve_open` | Ventil öffnen/schließen | `5200` (auf) / `5100` (zu) |
+| `switch.<gerät>_sleep_mode` | Sleep-Modus aktivieren/deaktivieren | `5400` / `5500` |
+| `switch.<gerät>_vacation_mode` | Urlaubsmodus aktivieren/deaktivieren | `5700` / `5800` |
+
+### Buttons
+
+| Entity-ID | Beschreibung | API |
+| --- | --- | --- |
+| `button.<gerät>_reset_alarms` | Meldungen/Alarme zurücksetzen | `6300` |
+| `button.<gerät>_start_microleak_test` | Mikrolecktest starten | `5C00` |
+| `button.<gerät>_start_learning` | Lernmodus starten | `5D00` |
+
+### Numbers (Schreiben)
+
+| Entity-ID | Beschreibung | API (Schreiben) |
+| --- | --- | --- |
+| `number.<gerät>_sleep_hours` | Sleepdauer 1–10 h (liest `6600`) | `5300` |
+| `number.<gerät>_absence_flow_limit` | Grenzwert Durchfluss (l/h) | `5F00` |
+| `number.<gerät>_absence_volume_limit` | Grenzwert Volumen (l) | `5F00` |
+| `number.<gerät>_absence_duration_limit` | Grenzwert Dauer (min) | `5F00` |
+
+### Selects
+
+| Entity-ID | Beschreibung | API |
+| --- | --- | --- |
+| `select.<gerät>_vacation_type` | Urlaubstyp `off/u1/u2/u3` | Lesen/Schreiben `5600` |
+| `select.<gerät>_microleak_mode_set` | Mikro-Leck-Betrieb `off/notify/notify_close` | Lesen `6500`, Schreiben `5B00` |
+
+### Binary Sensor
+
+| Entity-ID | Beschreibung | API |
+| --- | --- | --- |
+| `binary_sensor.<gerät>_learn_active` | Lernmodus aktiv | `6400` |
+
+### Sensoren (REST API)
+
+| Entity-ID | Beschreibung | API |
+| --- | --- | --- |
+| `sensor.<gerät>_sleep_duration` | Aktuelle Sleepdauer (h) | `6600` |
+| `sensor.<gerät>_absence_flow_limit` | Grenzwert Durchfluss (l/h) | `5E00` |
+| `sensor.<gerät>_absence_volume_limit` | Grenzwert Volumen (l) | `5E00` |
+| `sensor.<gerät>_absence_duration_limit` | Grenzwert Dauer (min) | `5E00` |
+| `sensor.<gerät>_total_water_liters` / `_total_water` | Gesamtverbrauch (l / m³) | `2800` |
+| `sensor.<gerät>_daily_usage` | Tagesverbrauch gesamt (l) | `FB00` |
+| `sensor.<gerät>_weekly_usage` | Wochenverbrauch gesamt (l) | `FC00` |
+| `sensor.<gerät>_monthly_usage` | Monatsverbrauch gesamt (l) | `FD00` |
+| `sensor.<gerät>_yearly_usage` | Jahresverbrauch gesamt (l) | `FE00` |
+| `sensor.<gerät>_learning_remaining_water` | Restwassermenge im Lernmodus | `6400` |
+| `sensor.<gerät>_device_time` | Gerätesystemzeit | `5900` |
+| `sensor.<gerät>_device_type` | Gerätemodell-Code | `FF00` |
+| `sensor.<gerät>_device_serial` | Seriennummer | `0600` |
+| `sensor.<gerät>_device_firmware` | Firmware-Version | `0100` |
+| `sensor.<gerät>_installation_date` | Inbetriebnahmedatum | `0E00` |
+
+Zusätzlich stellt die Integration Live-Werte wie Druck, Durchfluss, Temperatur, Batterie und letzter Kontakt über die JSON-Statusendpunkte bereit.
 
 > Achtung: Ventil-Steuerung kann die Wasserzufuhr schließen. Automationen mit Bedacht.
+
+## Services
+
+| Service | Beschreibung | API |
+| --- | --- | --- |
+| `judo_leakguard.set_datetime` | Gerätedatum/-zeit setzen | `5A00` |
+| `judo_leakguard.set_absence_schedule` | Abwesenheits-Zeitfenster schreiben (Slot 0–6) | `6100` |
+| `judo_leakguard.clear_absence_schedule` | Abwesenheits-Zeitfenster löschen | `6200` |
+
+Alle Dienste akzeptieren optional `config_entry_id` oder `device_id`, falls mehrere Geräte eingebunden sind. Beim Setzen eines Zeitfensters müssen Start-/Endtag (0 = Montag … 6 = Sonntag) sowie Stunde und Minute angegeben werden.
 
 ## Beispiele
 
 ### Ventil schließen/öffnen
 1. Öffne in Home Assistant **Entwicklerwerkzeuge → Dienste**.
 2. Wähle den Dienst `switch.turn_off` (zum Schließen) bzw. `switch.turn_on` (zum Öffnen).
-3. Trage als Entität `switch.judo_leakguard_valve` ein.
+3. Trage als Entität `switch.<gerät>_valve_open` ein.
 4. Ausführen – das Gerät ruft intern `GET /api/rest/5100` (zu) bzw. `GET /api/rest/5200` (auf).
 
 ### Sleep-Modus konfigurieren

--- a/custom_components/judo_leakguard/__init__.py
+++ b/custom_components/judo_leakguard/__init__.py
@@ -1,17 +1,33 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
-from typing import Any, Dict, Optional
+from datetime import datetime, timedelta
+from typing import Any, Dict, Mapping, Optional
+
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
-from .api import JudoLeakguardApi
-from .const import DOMAIN, DEFAULT_SCAN_INTERVAL, CONF_PORT, CONF_PROTOCOL, CONF_SEND_AS_QUERY, CONF_VERIFY_SSL
+from .api import (
+    JudoApiError,
+    JudoLeakguardApi,
+)
+from .const import (
+    CONF_PORT,
+    CONF_PROTOCOL,
+    CONF_SEND_AS_QUERY,
+    CONF_VERIFY_SSL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from .helpers import extract_serial
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +39,195 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SELECT,
 ]
+
+SERVICE_SET_DATETIME = "set_datetime"
+SERVICE_SET_ABSENCE = "set_absence_schedule"
+SERVICE_CLEAR_ABSENCE = "clear_absence_schedule"
+
+ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+ATTR_DEVICE_ID = "device_id"
+ATTR_DATETIME = "datetime"
+ATTR_SLOT = "slot"
+ATTR_START_DAY = "start_day"
+ATTR_START_HOUR = "start_hour"
+ATTR_START_MINUTE = "start_minute"
+ATTR_END_DAY = "end_day"
+ATTR_END_HOUR = "end_hour"
+ATTR_END_MINUTE = "end_minute"
+
+BASE_SERVICE_FIELDS: dict[Any, Any] = {
+    vol.Optional(ATTR_CONFIG_ENTRY_ID): cv.string,
+    vol.Optional(ATTR_DEVICE_ID): cv.string,
+}
+
+SERVICE_SET_DATETIME_SCHEMA = vol.Schema(
+    {**BASE_SERVICE_FIELDS, vol.Required(ATTR_DATETIME): cv.datetime}
+)
+
+SERVICE_SET_ABSENCE_SCHEMA = vol.Schema(
+    {
+        **BASE_SERVICE_FIELDS,
+        vol.Required(ATTR_SLOT): vol.All(int, vol.Range(min=0, max=6)),
+        vol.Required(ATTR_START_DAY): vol.All(int, vol.Range(min=0, max=6)),
+        vol.Required(ATTR_START_HOUR): vol.All(int, vol.Range(min=0, max=23)),
+        vol.Required(ATTR_START_MINUTE): vol.All(int, vol.Range(min=0, max=59)),
+        vol.Required(ATTR_END_DAY): vol.All(int, vol.Range(min=0, max=6)),
+        vol.Required(ATTR_END_HOUR): vol.All(int, vol.Range(min=0, max=23)),
+        vol.Required(ATTR_END_MINUTE): vol.All(int, vol.Range(min=0, max=59)),
+    }
+)
+
+SERVICE_CLEAR_ABSENCE_SCHEMA = vol.Schema(
+    {**BASE_SERVICE_FIELDS, vol.Required(ATTR_SLOT): vol.All(int, vol.Range(min=0, max=6))}
+)
+
+
+def _as_local_datetime(dt_value: datetime) -> datetime:
+    """Return ``dt_value`` converted to Home Assistant's local timezone."""
+
+    tz = dt_util.DEFAULT_TIME_ZONE
+    if dt_value.tzinfo is None:
+        if hasattr(tz, "localize"):
+            return tz.localize(dt_value)  # type: ignore[attr-defined]
+        return dt_value.replace(tzinfo=tz)
+    return dt_value.astimezone(tz)
+
+
+def _find_entry_id_by_serial(
+    hass_data: Dict[str, Dict[str, Any]],
+    serial: str,
+) -> str | None:
+    """Find the config entry that matches ``serial``."""
+
+    serial_upper = serial.upper()
+    for entry_id, entry_data in hass_data.items():
+        stored_serial = entry_data.get("serial")
+        if stored_serial is None:
+            coordinator = entry_data.get("coordinator")
+            if coordinator is not None:
+                entry_data["serial"] = str(
+                    extract_serial(getattr(coordinator, "data", None))
+                ).upper()
+                stored_serial = entry_data["serial"]
+        if stored_serial and str(stored_serial).upper() == serial_upper:
+            return entry_id
+    return None
+
+
+def _resolve_entry_id(hass: HomeAssistant, data: Mapping[str, Any]) -> str:
+    """Determine which config entry should handle a service call."""
+
+    domain_data: Dict[str, Dict[str, Any]] | None = hass.data.get(DOMAIN)
+    if not domain_data:
+        raise HomeAssistantError("JUDO Leakguard is not configured")
+
+    entry_id = data.get(ATTR_CONFIG_ENTRY_ID)
+    if entry_id:
+        if entry_id not in domain_data:
+            raise HomeAssistantError(f"Unknown config_entry_id: {entry_id}")
+        return entry_id
+
+    device_id = data.get(ATTR_DEVICE_ID)
+    if device_id:
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get(device_id)
+        if device is None:
+            raise HomeAssistantError(f"Device {device_id} not found")
+        serial_identifier: str | None = None
+        for domain, identifier in device.identifiers:
+            if domain == DOMAIN:
+                serial_identifier = str(identifier)
+                break
+        if serial_identifier is None:
+            raise HomeAssistantError("Device is not managed by JUDO Leakguard")
+        entry_id = _find_entry_id_by_serial(domain_data, serial_identifier)
+        if entry_id is None:
+            raise HomeAssistantError("No config entry matches the selected device")
+        return entry_id
+
+    if len(domain_data) == 1:
+        return next(iter(domain_data))
+
+    raise HomeAssistantError(
+        "Multiple JUDO Leakguard devices configured. Specify config_entry_id or device_id."
+    )
+
+
+async def _async_register_services(hass: HomeAssistant) -> None:
+    """Register domain services once."""
+
+    if hass.services.has_service(DOMAIN, SERVICE_SET_DATETIME):
+        return
+
+    async def _handle_set_datetime(call: ServiceCall) -> None:
+        entry_id = _resolve_entry_id(hass, call.data)
+        entry_data = hass.data[DOMAIN][entry_id]
+        api: JudoLeakguardApi = entry_data["api"]
+        coordinator: JudoLeakguardCoordinator = entry_data["coordinator"]
+        dt_value: datetime = call.data[ATTR_DATETIME]
+        dt_local = _as_local_datetime(dt_value)
+        try:
+            await api.write_device_time(dt_local)
+        except JudoApiError as exc:
+            raise HomeAssistantError(f"Failed to set device time: {exc}") from exc
+        await coordinator.async_request_refresh()
+
+    async def _handle_set_absence(call: ServiceCall) -> None:
+        entry_id = _resolve_entry_id(hass, call.data)
+        entry_data = hass.data[DOMAIN][entry_id]
+        api: JudoLeakguardApi = entry_data["api"]
+        coordinator: JudoLeakguardCoordinator = entry_data["coordinator"]
+        try:
+            await api.write_absence_time(
+                call.data[ATTR_SLOT],
+                call.data[ATTR_START_DAY],
+                call.data[ATTR_START_HOUR],
+                call.data[ATTR_START_MINUTE],
+                call.data[ATTR_END_DAY],
+                call.data[ATTR_END_HOUR],
+                call.data[ATTR_END_MINUTE],
+            )
+        except JudoApiError as exc:
+            raise HomeAssistantError(f"Failed to set absence schedule: {exc}") from exc
+        await coordinator.async_request_refresh()
+
+    async def _handle_clear_absence(call: ServiceCall) -> None:
+        entry_id = _resolve_entry_id(hass, call.data)
+        entry_data = hass.data[DOMAIN][entry_id]
+        api: JudoLeakguardApi = entry_data["api"]
+        coordinator: JudoLeakguardCoordinator = entry_data["coordinator"]
+        try:
+            await api.delete_absence_time(call.data[ATTR_SLOT])
+        except JudoApiError as exc:
+            raise HomeAssistantError(f"Failed to clear absence schedule: {exc}") from exc
+        await coordinator.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_DATETIME,
+        _handle_set_datetime,
+        schema=SERVICE_SET_DATETIME_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_ABSENCE,
+        _handle_set_absence,
+        schema=SERVICE_SET_ABSENCE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAR_ABSENCE,
+        _handle_clear_absence,
+        schema=SERVICE_CLEAR_ABSENCE_SCHEMA,
+    )
+
+
+def _unregister_services(hass: HomeAssistant) -> None:
+    """Remove domain services when the last entry is unloaded."""
+
+    for service in (SERVICE_SET_DATETIME, SERVICE_SET_ABSENCE, SERVICE_CLEAR_ABSENCE):
+        if hass.services.has_service(DOMAIN, service):
+            hass.services.async_remove(DOMAIN, service)
 
 
 class JudoLeakguardCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
@@ -95,13 +300,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = JudoLeakguardCoordinator(hass, api, update_interval)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = {
+    entry_data: Dict[str, Any] = {
         "coordinator": coordinator,
         "api": api,
         "client": api,
         "base_url": base_url,
         "send_as_query": send_as_query,
     }
+    hass.data[DOMAIN][entry.entry_id] = entry_data
+
+    def _update_serial() -> None:
+        entry_data["serial"] = str(extract_serial(coordinator.data)).upper()
+
+    _update_serial()
+    entry.async_on_unload(coordinator.async_add_listener(_update_serial))
+
+    await _async_register_services(hass)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_reload_if_options_changed))
@@ -116,5 +330,8 @@ async def _async_reload_if_options_changed(hass: HomeAssistant, entry: ConfigEnt
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        domain_entries = hass.data.get(DOMAIN, {})
+        domain_entries.pop(entry.entry_id, None)
+        if not domain_entries:
+            _unregister_services(hass)
     return unload_ok

--- a/custom_components/judo_leakguard/manifest.json
+++ b/custom_components/judo_leakguard/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/SilvesterSchneider/homeassistant-judo-leakguard/issues",
   "loggers": ["custom_components.judo_leakguard"],
   "requirements": [],
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/custom_components/judo_leakguard/number.py
+++ b/custom_components/judo_leakguard/number.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from homeassistant.components.number import NumberEntity
+from homeassistant.const import UnitOfTime, UnitOfVolume, UnitOfVolumeFlowRate
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import JudoClient
@@ -34,6 +36,8 @@ class SleepHours(_Base):
     _attr_native_min_value = 1
     _attr_native_max_value = 10
     _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+    _attr_entity_category = EntityCategory.CONFIG
     def __init__(self, coordinator, client: JudoClient, entry):
         super().__init__(coordinator, client, entry, "sleep_hours")
     @property
@@ -47,7 +51,9 @@ class FlowLimit(_Base):
     _attr_translation_key = "absence_flow_limit"
     _attr_native_min_value = 0
     _attr_native_max_value = 65535
-    _attr_native_step = 10
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.LITERS_PER_HOUR
+    _attr_entity_category = EntityCategory.CONFIG
     def __init__(self, coordinator, client: JudoClient, entry):
         super().__init__(coordinator, client, entry, "absence_flow")
     @property
@@ -65,6 +71,8 @@ class VolumeLimit(_Base):
     _attr_native_min_value = 0
     _attr_native_max_value = 65535
     _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
+    _attr_entity_category = EntityCategory.CONFIG
     def __init__(self, coordinator, client: JudoClient, entry):
         super().__init__(coordinator, client, entry, "absence_volume")
     @property
@@ -82,6 +90,8 @@ class DurationLimit(_Base):
     _attr_native_min_value = 0
     _attr_native_max_value = 65535
     _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_entity_category = EntityCategory.CONFIG
     def __init__(self, coordinator, client: JudoClient, entry):
         super().__init__(coordinator, client, entry, "absence_duration")
     @property

--- a/custom_components/judo_leakguard/services.yaml
+++ b/custom_components/judo_leakguard/services.yaml
@@ -1,0 +1,140 @@
+set_datetime:
+  name: Set device date and time
+  description: Update the internal clock of the ZEWA i-SAFE device.
+  fields:
+    config_entry_id:
+      name: Config entry
+      description: Limit the service call to a specific integration entry. Only needed when multiple Leakguard devices are configured.
+      required: false
+      example: "1a2b3c4d5e6f7a8b9c0d123456789abc"
+      selector:
+        text:
+    device_id:
+      name: Device
+      description: Target a specific Leakguard device. Overrides the config_entry_id when provided.
+      required: false
+      selector:
+        device:
+          integration: judo_leakguard
+    datetime:
+      name: Date & time
+      description: Local date and time that should be written to the device clock.
+      required: true
+      selector:
+        datetime:
+
+set_absence_schedule:
+  name: Set absence schedule
+  description: Configure one of the absence monitoring schedule slots (index 0–6).
+  fields:
+    config_entry_id:
+      name: Config entry
+      description: Limit the service call to a specific integration entry. Only needed when multiple Leakguard devices are configured.
+      required: false
+      selector:
+        text:
+    device_id:
+      name: Device
+      description: Target a specific Leakguard device. Overrides the config_entry_id when provided.
+      required: false
+      selector:
+        device:
+          integration: judo_leakguard
+    slot:
+      name: Slot
+      description: Schedule slot index (0–6).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 6
+          step: 1
+          mode: box
+    start_day:
+      name: Start day
+      description: Start weekday (0 = Monday … 6 = Sunday).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 6
+          step: 1
+          mode: box
+    start_hour:
+      name: Start hour
+      description: Start hour in 24h format (0–23).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 23
+          step: 1
+          mode: box
+    start_minute:
+      name: Start minute
+      description: Start minute (0–59).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 59
+          step: 1
+          mode: box
+    end_day:
+      name: End day
+      description: End weekday (0 = Monday … 6 = Sunday).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 6
+          step: 1
+          mode: box
+    end_hour:
+      name: End hour
+      description: End hour in 24h format (0–23).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 23
+          step: 1
+          mode: box
+    end_minute:
+      name: End minute
+      description: End minute (0–59).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 59
+          step: 1
+          mode: box
+
+clear_absence_schedule:
+  name: Clear absence schedule
+  description: Delete an absence monitoring schedule slot.
+  fields:
+    config_entry_id:
+      name: Config entry
+      description: Limit the service call to a specific integration entry. Only needed when multiple Leakguard devices are configured.
+      required: false
+      selector:
+        text:
+    device_id:
+      name: Device
+      description: Target a specific Leakguard device. Overrides the config_entry_id when provided.
+      required: false
+      selector:
+        device:
+          integration: judo_leakguard
+    slot:
+      name: Slot
+      description: Schedule slot index (0–6) that should be cleared.
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 6
+          step: 1
+          mode: box

--- a/custom_components/judo_leakguard/translations/de.json
+++ b/custom_components/judo_leakguard/translations/de.json
@@ -62,6 +62,30 @@
       },
       "installation_date": {
         "name": "Installationsdatum"
+      },
+      "device_time": {
+        "name": "Gerätezeit"
+      },
+      "device_type": {
+        "name": "Gerätetyp"
+      },
+      "device_serial": {
+        "name": "Seriennummer"
+      },
+      "device_firmware": {
+        "name": "Firmware-Version"
+      },
+      "daily_usage": {
+        "name": "Tagesverbrauch"
+      },
+      "weekly_usage": {
+        "name": "Wochenverbrauch"
+      },
+      "monthly_usage": {
+        "name": "Monatsverbrauch"
+      },
+      "yearly_usage": {
+        "name": "Jahresverbrauch"
       }
     },
     "binary_sensor": {
@@ -99,9 +123,9 @@
         "name": "Urlaubsmodus",
         "state": {
           "off": "Aus",
-          "U1": "U1",
-          "U2": "U2",
-          "U3": "U3"
+          "u1": "U1",
+          "u2": "U2",
+          "u3": "U3"
         }
       },
       "microleak_mode_set": {

--- a/custom_components/judo_leakguard/translations/en.json
+++ b/custom_components/judo_leakguard/translations/en.json
@@ -62,6 +62,30 @@
       },
       "installation_date": {
         "name": "Installation date"
+      },
+      "device_time": {
+        "name": "Device time"
+      },
+      "device_type": {
+        "name": "Device type"
+      },
+      "device_serial": {
+        "name": "Serial number"
+      },
+      "device_firmware": {
+        "name": "Firmware version"
+      },
+      "daily_usage": {
+        "name": "Daily water usage"
+      },
+      "weekly_usage": {
+        "name": "Weekly water usage"
+      },
+      "monthly_usage": {
+        "name": "Monthly water usage"
+      },
+      "yearly_usage": {
+        "name": "Yearly water usage"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
## Summary
- extend the API coordinator to collect ZEWA i-SAFE statistics, device metadata and normalized timestamps
- expose the full set of switches, numbers, selects, sensors and services mapped to the 0x01–0xFE REST commands
- add translations, documentation updates and a services.yaml so Home Assistant and HACS validation data stay consistent

## Testing
- python3 -m script.hassfest *(fails: ModuleNotFoundError: No module named 'script')*
- python3 -m hassfest *(fails: No module named hassfest; installing hassfest blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b2eed2d88321b5f7b1d32b0814c0