### PR TITLE
Add offline harness, coverage plugin, and API tests

### DIFF
--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -65,6 +65,10 @@ class _MockResponse:
         await asyncio.sleep(0)
         return self._body
 
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise ClientResponseError(self.status)
+
     async def __aenter__(self) -> "_MockResponse":
         return self
 
@@ -104,6 +108,12 @@ class ClientSession:
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - compatibility
         self._closed = False
+
+    async def __aenter__(self) -> "ClientSession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
 
     @property
     def closed(self) -> bool:

--- a/homeassistant/__init__.py
+++ b/homeassistant/__init__.py
@@ -1,0 +1,8 @@
+"""Minimal Home Assistant test harness used for the integration tests."""
+
+from __future__ import annotations
+
+from . import config_entries
+from .core import HomeAssistant, ServiceCall
+
+__all__ = ["HomeAssistant", "ServiceCall", "config_entries"]

--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -1,0 +1,1 @@
+"""Component namespace for the lightweight Home Assistant harness."""

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -1,0 +1,34 @@
+"""Minimal binary sensor entity."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from homeassistant.helpers.entity import Entity
+
+
+class BinarySensorDeviceClass(str, Enum):
+    SAFETY = "safety"
+    PROBLEM = "problem"
+
+
+class BinarySensorEntity(Entity):
+    @property
+    def is_on(self) -> bool:
+        return getattr(self, "_attr_is_on", False)
+
+    @property
+    def state(self) -> str:
+        return "on" if self.is_on else "off"
+
+    def async_write_ha_state(self) -> None:
+        if self.hass is None or self.entity_id is None:
+            return
+        attrs = dict(self.extra_state_attributes or {})
+        device_class = getattr(self, "_attr_device_class", None)
+        if device_class is not None:
+            attrs["device_class"] = device_class
+        self.hass.states.async_set(self.entity_id, self.state, attrs)
+
+
+__all__ = ["BinarySensorDeviceClass", "BinarySensorEntity"]

--- a/homeassistant/components/button/__init__.py
+++ b/homeassistant/components/button/__init__.py
@@ -1,0 +1,17 @@
+"""Minimal button entity."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.entity import Entity
+
+
+class ButtonEntity(Entity):
+    async def async_press(self) -> None:  # pragma: no cover - overridden by entities
+        raise NotImplementedError
+
+    @property
+    def state(self) -> str:
+        return "unknown"
+
+
+__all__ = ["ButtonEntity"]

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -1,0 +1,54 @@
+"""Minimal number entity."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.helpers.entity import Entity
+
+
+class NumberEntity(Entity):
+    _attr_native_value: Optional[float] = None
+    _attr_native_min_value: Optional[float] = None
+    _attr_native_max_value: Optional[float] = None
+    _attr_native_step: Optional[float] = None
+    _attr_native_unit_of_measurement: Optional[str] = None
+
+    @property
+    def native_value(self) -> Optional[float]:
+        return getattr(self, "_attr_native_value", None)
+
+    @property
+    def native_unit_of_measurement(self) -> Optional[str]:
+        return getattr(self, "_attr_native_unit_of_measurement", None)
+
+    async def async_set_native_value(self, value: float) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    @property
+    def state(self) -> Any:
+        value = self.native_value
+        if value is None:
+            return STATE_UNKNOWN
+        if int(value) == value:
+            return str(int(value))
+        return str(value)
+
+    def async_write_ha_state(self) -> None:
+        if self.hass is None or self.entity_id is None:
+            return
+        attrs = dict(self.extra_state_attributes or {})
+        unit = self.native_unit_of_measurement
+        if unit is not None:
+            attrs["unit_of_measurement"] = unit
+        if self._attr_native_min_value is not None:
+            attrs["native_min_value"] = self._attr_native_min_value
+        if self._attr_native_max_value is not None:
+            attrs["native_max_value"] = self._attr_native_max_value
+        if self._attr_native_step is not None:
+            attrs["native_step"] = self._attr_native_step
+        self.hass.states.async_set(self.entity_id, self.state, attrs)
+
+
+__all__ = ["NumberEntity"]

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -1,0 +1,38 @@
+"""Minimal select entity."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.helpers.entity import Entity
+
+
+class SelectEntity(Entity):
+    _attr_options: List[str] = []
+    _attr_current_option: Optional[str] = None
+
+    @property
+    def options(self) -> List[str]:
+        return list(getattr(self, "_attr_options", []))
+
+    @property
+    def current_option(self) -> Optional[str]:
+        return getattr(self, "_attr_current_option", None)
+
+    async def async_select_option(self, option: str) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    @property
+    def state(self) -> str:
+        return self.current_option or STATE_UNKNOWN
+
+    def async_write_ha_state(self) -> None:
+        if self.hass is None or self.entity_id is None:
+            return
+        attrs = dict(self.extra_state_attributes or {})
+        attrs["options"] = self.options
+        self.hass.states.async_set(self.entity_id, self.state, attrs)
+
+
+__all__ = ["SelectEntity"]

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -1,0 +1,92 @@
+"""Minimal sensor entity implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional
+
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.helpers.entity import Entity, EntityCategory
+
+
+class SensorDeviceClass(str, Enum):
+    WATER = "water"
+    TIMESTAMP = "timestamp"
+
+
+class SensorStateClass(str, Enum):
+    MEASUREMENT = "measurement"
+    TOTAL_INCREASING = "total_increasing"
+
+
+@dataclass(frozen=True)
+class SensorEntityDescription:
+    key: str
+    translation_key: Optional[str] = None
+    native_unit_of_measurement: Optional[str] = None
+    device_class: Optional[SensorDeviceClass] = None
+    state_class: Optional[SensorStateClass] = None
+    entity_category: Optional[EntityCategory] = None
+    paths: tuple[str, ...] = ()
+
+
+class SensorEntity(Entity):
+    _attr_native_unit_of_measurement: Optional[str] = None
+    _attr_device_class: Optional[SensorDeviceClass] = None
+    _attr_state_class: Optional[SensorStateClass] = None
+
+    @property
+    def native_value(self) -> Any:
+        return getattr(self, "_attr_native_value", None)
+
+    @property
+    def native_unit_of_measurement(self) -> Optional[str]:
+        if hasattr(self, "entity_description"):
+            return getattr(self.entity_description, "native_unit_of_measurement", None)
+        return getattr(self, "_attr_native_unit_of_measurement", None)
+
+    @property
+    def device_class(self) -> Optional[SensorDeviceClass]:
+        if hasattr(self, "entity_description"):
+            return getattr(self.entity_description, "device_class", None)
+        return getattr(self, "_attr_device_class", None)
+
+    @property
+    def state_class(self) -> Optional[SensorStateClass]:
+        if hasattr(self, "entity_description"):
+            return getattr(self.entity_description, "state_class", None)
+        return getattr(self, "_attr_state_class", None)
+
+    @property
+    def state(self) -> Any:
+        value = self.native_value
+        if value is None:
+            return STATE_UNKNOWN
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return str(value)
+
+    def async_write_ha_state(self) -> None:
+        if self.hass is None or self.entity_id is None:
+            return
+        attrs = dict(self.extra_state_attributes or {})
+        unit = self.native_unit_of_measurement
+        if unit is not None:
+            attrs["unit_of_measurement"] = unit
+        device_class = self.device_class
+        if device_class is not None:
+            attrs["device_class"] = device_class
+        state_class = self.state_class
+        if state_class is not None:
+            attrs["state_class"] = state_class
+        self.hass.states.async_set(self.entity_id, self.state, attrs)
+
+
+__all__ = [
+    "SensorDeviceClass",
+    "SensorEntity",
+    "SensorEntityDescription",
+    "SensorStateClass",
+]

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -1,0 +1,30 @@
+"""Minimal switch entity implementation."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.entity import Entity
+
+
+class SwitchEntity(Entity):
+    @property
+    def is_on(self) -> bool:
+        return getattr(self, "_attr_is_on", False)
+
+    async def async_turn_on(self, **kwargs):  # pragma: no cover - overridden by entities
+        raise NotImplementedError
+
+    async def async_turn_off(self, **kwargs):  # pragma: no cover - overridden by entities
+        raise NotImplementedError
+
+    @property
+    def state(self) -> str:
+        return "on" if self.is_on else "off"
+
+    def async_write_ha_state(self) -> None:
+        if self.hass is None or self.entity_id is None:
+            return
+        attrs = dict(self.extra_state_attributes or {})
+        self.hass.states.async_set(self.entity_id, self.state, attrs)
+
+
+__all__ = ["SwitchEntity"]

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1,0 +1,268 @@
+"""Minimal configuration entry framework for tests."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable, Dict, Iterable, List, Optional
+from uuid import uuid4
+
+HANDLERS: Dict[str, type["ConfigFlow"]] = {}
+
+SOURCE_USER = "user"
+
+
+class ConfigEntryState:
+    LOADED = "loaded"
+    NOT_LOADED = "not_loaded"
+
+
+class ConfigFlow:
+    """Base class for configuration flows."""
+
+    VERSION = 1
+
+    def __init_subclass__(cls, *, domain: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if domain is not None:
+            cls.domain = domain
+            HANDLERS[domain] = cls
+
+    def __init__(self) -> None:
+        self.hass = None
+        self.context: Dict[str, Any] = {}
+        self._unique_id: Optional[str] = None
+
+    async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):  # pragma: no cover - overridden in tests
+        raise NotImplementedError
+
+    async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None):  # pragma: no cover
+        raise NotImplementedError
+
+    async def async_set_unique_id(self, unique_id: str) -> None:
+        self._unique_id = unique_id
+
+    def _async_current_entries(self) -> List["ConfigEntry"]:
+        if self.hass is None or self.hass.config_entries is None:
+            return []
+        return list(self.hass.config_entries._entries.values())
+
+    def _abort_if_unique_id_configured(self) -> None:
+        if self._unique_id is None:
+            return
+        for entry in self._async_current_entries():
+            if entry.unique_id == self._unique_id:
+                raise AbortFlow("already_configured")
+
+    def async_show_form(self, *, step_id: str, data_schema: Any, errors: Optional[Dict[str, str]] = None):
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+        }
+
+    def async_create_entry(self, *, title: str, data: Dict[str, Any]):
+        return {
+            "type": "create_entry",
+            "title": title,
+            "data": data,
+        }
+
+    def async_abort(self, *, reason: str):
+        return {
+            "type": "abort",
+            "reason": reason,
+        }
+
+
+class AbortFlow(Exception):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class OptionsFlow:
+    def async_show_form(self, *, step_id: str, data_schema: Any, errors: Optional[Dict[str, str]] = None):
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+        }
+
+    def async_create_entry(self, *, title: str, data: Dict[str, Any]):
+        return {
+            "type": "create_entry",
+            "title": title,
+            "data": data,
+        }
+
+
+@dataclass
+class ConfigEntry:
+    domain: str
+    title: str
+    data: Dict[str, Any]
+    options: Dict[str, Any]
+    entry_id: str
+    unique_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.hass = None
+        self.state = ConfigEntryState.NOT_LOADED
+        self._on_unload: List[Callable[[], Any]] = []
+        self._update_listeners: List[Callable[["HomeAssistant", "ConfigEntry"], Any]] = []
+
+    def add_to_hass(self, hass: "HomeAssistant") -> None:
+        self.hass = hass
+        hass.config_entries._add(self)
+
+    def add_update_listener(self, listener: Callable[["HomeAssistant", "ConfigEntry"], Any]) -> Callable[[], None]:
+        self._update_listeners.append(listener)
+
+        def _remove() -> None:
+            self._update_listeners.remove(listener)
+
+        return _remove
+
+    def async_on_unload(self, callback: Callable[[], Any]) -> None:
+        self._on_unload.append(callback)
+
+    async def async_unload(self) -> None:
+        for callback in list(self._on_unload):
+            result = callback()
+            if inspect.isawaitable(result):
+                await result
+        self._on_unload.clear()
+
+
+class ConfigEntriesFlowManager:
+    def __init__(self, hass: "HomeAssistant") -> None:
+        self.hass = hass
+        self._flows: Dict[str, Dict[str, Any]] = {}
+
+    async def async_init(self, domain: str, *, context: Optional[Dict[str, Any]] = None):
+        handler = HANDLERS.get(domain)
+        if handler is None:
+            raise ValueError(f"No config flow handler for domain {domain}")
+        flow = handler()
+        flow.hass = self.hass
+        flow.context = context or {}
+        flow_id = uuid4().hex
+        try:
+            result = await flow.async_step_user()
+        except AbortFlow as exc:
+            return {"type": "abort", "reason": exc.reason, "flow_id": flow_id}
+        if result["type"] == "form":
+            result["flow_id"] = flow_id
+            self._flows[flow_id] = {"flow": flow, "step_id": result["step_id"]}
+        else:
+            result["flow_id"] = flow_id
+        return result
+
+    async def async_configure(self, flow_id: str, user_input: Optional[Dict[str, Any]] = None):
+        if flow_id not in self._flows:
+            raise ValueError(f"Unknown flow_id: {flow_id}")
+        entry = self._flows[flow_id]
+        flow: ConfigFlow = entry["flow"]
+        step_id: str = entry["step_id"]
+        step_method = getattr(flow, f"async_step_{step_id}")
+        try:
+            result = await step_method(user_input)
+        except AbortFlow as exc:
+            self._flows.pop(flow_id, None)
+            return {"type": "abort", "reason": exc.reason, "flow_id": flow_id}
+        result["flow_id"] = flow_id
+        if result["type"] == "form":
+            entry["step_id"] = result["step_id"]
+        else:
+            self._flows.pop(flow_id, None)
+        return result
+
+
+class ConfigEntries:
+    def __init__(self, hass: "HomeAssistant") -> None:
+        self.hass = hass
+        self._entries: Dict[str, ConfigEntry] = {}
+        self.flow = ConfigEntriesFlowManager(hass)
+        hass.attach_config_entries(self)
+
+    def _add(self, entry: ConfigEntry) -> None:
+        self._entries[entry.entry_id] = entry
+
+    def async_entries(self) -> List[ConfigEntry]:
+        return list(self._entries.values())
+
+    async def async_setup(self, entry_id: str) -> bool:
+        entry = self._entries[entry_id]
+        module = import_module(f"custom_components.{entry.domain}")
+        setup = getattr(module, "async_setup_entry")
+        success = await setup(self.hass, entry)
+        if success:
+            entry.state = ConfigEntryState.LOADED
+        return success
+
+    async def async_forward_entry_setups(self, entry: ConfigEntry, platforms: Iterable[Any]) -> None:
+        tasks: List[asyncio.Task[Any]] = []
+        for platform in platforms:
+            platform_name = getattr(platform, "value", str(platform))
+            module = import_module(f"custom_components.{entry.domain}.{platform_name}")
+
+            def _add_entities(entities: Iterable[Any], update_before_add: bool = False, *, _platform=platform_name) -> None:
+                task = self.hass.async_create_task(
+                    self.hass._async_add_entities(entry, _platform, entry.domain, list(entities), update_before_add)
+                )
+                tasks.append(task)
+
+            setup = getattr(module, "async_setup_entry")
+            await setup(self.hass, entry, _add_entities)
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    async def async_unload_platforms(self, entry: ConfigEntry, platforms: Iterable[Any]) -> bool:
+        unload_ok = True
+        for platform in platforms:
+            platform_name = getattr(platform, "value", str(platform))
+            module = import_module(f"custom_components.{entry.domain}.{platform_name}")
+            unload = getattr(module, "async_unload_entry", None)
+            if unload is not None:
+                result = await unload(self.hass, entry)
+                unload_ok = unload_ok and bool(result)
+        self.hass._remove_entities_for_entry(entry.entry_id)
+        return unload_ok
+
+    async def async_unload(self, entry_id: str) -> bool:
+        entry = self._entries.get(entry_id)
+        if entry is None:
+            return False
+        module = import_module(f"custom_components.{entry.domain}")
+        unload = getattr(module, "async_unload_entry", None)
+        if unload is None:
+            return False
+        success = await unload(self.hass, entry)
+        if success:
+            await entry.async_unload()
+            entry.state = ConfigEntryState.NOT_LOADED
+        return success
+
+    async def async_reload(self, entry_id: str) -> bool:
+        if entry_id not in self._entries:
+            return False
+        success = await self.async_unload(entry_id)
+        if not success:
+            return False
+        return await self.async_setup(entry_id)
+
+
+__all__ = [
+    "ConfigEntries",
+    "ConfigEntriesFlowManager",
+    "ConfigEntry",
+    "ConfigEntryState",
+    "ConfigFlow",
+    "OptionsFlow",
+    "SOURCE_USER",
+]

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,0 +1,67 @@
+"""Subset of Home Assistant constants required for the tests."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+CONF_HOST = "host"
+CONF_PASSWORD = "password"
+CONF_USERNAME = "username"
+CONF_PORT = "port"
+CONF_PROTOCOL = "protocol"
+CONF_VERIFY_SSL = "verify_ssl"
+
+STATE_UNKNOWN = "unknown"
+PERCENTAGE = "%"
+
+
+class UnitOfTime(str, Enum):
+    SECONDS = "s"
+    MINUTES = "min"
+    HOURS = "h"
+
+
+class UnitOfVolume(str, Enum):
+    LITERS = "L"
+    CUBIC_METERS = "m³"
+
+
+class UnitOfVolumeFlowRate(str, Enum):
+    LITERS_PER_HOUR = "L/h"
+    LITERS_PER_MINUTE = "L/min"
+
+
+class UnitOfPressure(str, Enum):
+    BAR = "bar"
+
+
+class UnitOfTemperature(str, Enum):
+    CELSIUS = "°C"
+
+
+class Platform(str, Enum):
+    BINARY_SENSOR = "binary_sensor"
+    BUTTON = "button"
+    NUMBER = "number"
+    SELECT = "select"
+    SENSOR = "sensor"
+    SWITCH = "switch"
+
+
+__all__ = [
+    "CONF_HOST",
+    "CONF_PASSWORD",
+    "CONF_PORT",
+    "CONF_PROTOCOL",
+    "CONF_USERNAME",
+    "CONF_VERIFY_SSL",
+    "PERCENTAGE",
+    "Platform",
+    "STATE_UNKNOWN",
+    "UnitOfPressure",
+    "UnitOfTemperature",
+    "UnitOfTime",
+    "UnitOfVolume",
+    "UnitOfVolumeFlowRate",
+]

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1,0 +1,237 @@
+"""Core primitives for the lightweight Home Assistant test harness."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, Set
+
+from .exceptions import HomeAssistantError
+from .helpers import device_registry as dr, entity_registry as er
+
+
+@dataclass
+class ServiceCall:
+    hass: "HomeAssistant"
+    domain: str
+    service: str
+    data: Dict[str, Any]
+
+
+@dataclass
+class State:
+    entity_id: str
+    state: str
+    attributes: Dict[str, Any]
+
+
+class StateMachine:
+    def __init__(self, hass: "HomeAssistant") -> None:
+        self._states: Dict[str, State] = {}
+        self.hass = hass
+
+    def get(self, entity_id: str) -> Optional[State]:
+        return self._states.get(entity_id)
+
+    def async_set(self, entity_id: str, state: Any, attributes: Optional[Dict[str, Any]] = None) -> None:
+        state_str = "unknown" if state is None else str(state)
+        self._states[entity_id] = State(entity_id=entity_id, state=state_str, attributes=attributes or {})
+
+    def async_remove(self, entity_id: str) -> None:
+        self._states.pop(entity_id, None)
+
+
+class ServiceRegistry:
+    def __init__(self, hass: "HomeAssistant") -> None:
+        self.hass = hass
+        self._handlers: Dict[str, Dict[str, Callable[[ServiceCall], Any]]] = {}
+        self._entity_handlers: Dict[str, Dict[str, str]] = {}
+
+    def async_register(
+        self,
+        domain: str,
+        service: str,
+        handler: Callable[[ServiceCall], Any],
+        *,
+        schema: Any = None,
+    ) -> None:
+        self._handlers.setdefault(domain, {})[service] = handler
+
+    def async_remove(self, domain: str, service: str) -> None:
+        self._handlers.get(domain, {}).pop(service, None)
+
+    def has_service(self, domain: str, service: str) -> bool:
+        return service in self._handlers.get(domain, {}) or service in self._entity_handlers.get(domain, {})
+
+    def register_entity_service(self, domain: str, service: str, method_name: str) -> None:
+        self._entity_handlers.setdefault(domain, {})[service] = method_name
+
+    async def async_call(
+        self,
+        domain: str,
+        service: str,
+        data: Optional[Dict[str, Any]] = None,
+        *,
+        blocking: bool = False,
+    ) -> None:
+        data = dict(data or {})
+        handler = self._handlers.get(domain, {}).get(service)
+        if handler is not None:
+            call = ServiceCall(self.hass, domain, service, data)
+            result = handler(call)
+            if inspect.isawaitable(result):
+                if blocking:
+                    await result
+                else:
+                    self.hass.async_create_task(result)
+            elif blocking:
+                await self.hass.async_block_till_done()
+            return
+
+        entity_services = self._entity_handlers.get(domain)
+        if entity_services and service in entity_services:
+            entity_id = data.get("entity_id")
+            if not entity_id:
+                raise HomeAssistantError("entity_id required for entity service call")
+            entity = self.hass.get_entity(entity_id)
+            if entity is None:
+                raise HomeAssistantError(f"Entity {entity_id} not found")
+            method_name = entity_services[service]
+            if not hasattr(entity, method_name):
+                raise HomeAssistantError(f"Entity {entity_id} does not implement {method_name}")
+            method = getattr(entity, method_name)
+            call_kwargs = dict(data)
+            call_kwargs.pop("entity_id", None)
+            result = method(**call_kwargs)
+            if inspect.isawaitable(result):
+                if blocking:
+                    await result
+                else:
+                    self.hass.async_create_task(result)
+            if blocking:
+                await self.hass.async_block_till_done()
+            return
+
+        raise HomeAssistantError(f"Service {domain}.{service} not found")
+
+
+_SLUGIFY_RE = re.compile(r"[^a-z0-9_]+")
+
+
+def _slugify(value: str) -> str:
+    value = value.strip().lower().replace(" ", "_")
+    return _SLUGIFY_RE.sub("_", value)
+
+
+class HomeAssistant:
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+        self.data: Dict[str, Any] = {}
+        self.states = StateMachine(self)
+        self.services = ServiceRegistry(self)
+        self.config_entries = None  # delayed import to avoid cycle
+        self._entities: Dict[str, Any] = {}
+        self._entity_sources: Dict[str, Set[str]] = {}
+        self._tasks: Set[asyncio.Task[Any]] = set()
+        self._entity_counters: Dict[str, int] = {}
+
+        # Entity services for the supported domains
+        self.services.register_entity_service("button", "press", "async_press")
+        self.services.register_entity_service("switch", "turn_on", "async_turn_on")
+        self.services.register_entity_service("switch", "turn_off", "async_turn_off")
+        self.services.register_entity_service("number", "set_value", "async_set_native_value")
+        self.services.register_entity_service("select", "select_option", "async_select_option")
+
+    def attach_config_entries(self, manager) -> None:
+        self.config_entries = manager
+
+    def async_create_task(self, coro: Awaitable[Any]) -> asyncio.Task[Any]:
+        task = self.loop.create_task(coro)
+        self._tasks.add(task)
+
+        def _done(_):
+            self._tasks.discard(task)
+
+        task.add_done_callback(_done)
+        return task
+
+    async def async_block_till_done(self) -> None:
+        await asyncio.sleep(0)
+        pending = [task for task in self._tasks if not task.done()]
+        for task in pending:
+            await asyncio.sleep(0)
+
+    async def async_stop(self) -> None:
+        for task in list(self._tasks):
+            task.cancel()
+        await asyncio.sleep(0)
+
+    def get_entity(self, entity_id: str):
+        return self._entities.get(entity_id)
+
+    def _next_entity_id(self, domain: str) -> str:
+        self._entity_counters.setdefault(domain, 0)
+        self._entity_counters[domain] += 1
+        return f"{domain}.{domain}_{self._entity_counters[domain]}"
+
+    async def _async_add_entities(
+        self,
+        entry,
+        domain: str,
+        platform: str,
+        entities: Iterable[Any],
+        update_before_add: bool,
+    ) -> None:
+        entity_registry = er.async_get(self)
+        device_registry = dr.async_get(self)
+        for entity in entities:
+            entity.hass = self
+            if update_before_add:
+                await entity.async_update()
+            unique_id = getattr(entity, "unique_id", None)
+            if unique_id:
+                object_id = _slugify(str(unique_id))
+                entity_id = f"{domain}.{object_id}"
+            else:
+                entity_id = self._next_entity_id(domain)
+            entity.entity_id = entity_id
+
+            device_id = None
+            device_info = getattr(entity, "device_info", None)
+            if device_info is not None:
+                identifiers = set(tuple(pair) for pair in device_info.identifiers)
+                entry_info = device_registry.async_get_or_create(
+                    config_entry_id=entry.entry_id,
+                    identifiers=identifiers,
+                    manufacturer=device_info.manufacturer,
+                    model=device_info.model,
+                    name=device_info.name,
+                    sw_version=device_info.sw_version,
+                )
+                device_id = entry_info.id
+
+            entity_registry._register(
+                domain,
+                platform,
+                unique_id,
+                entity_id,
+                device_id=device_id,
+                config_entry_id=entry.entry_id,
+            )
+            self._entities[entity_id] = entity
+            self._entity_sources.setdefault(entry.entry_id, set()).add(entity_id)
+            await entity.async_added_to_hass()
+            entity.async_write_ha_state()
+
+    def _remove_entities_for_entry(self, entry_id: str) -> None:
+        entity_ids = self._entity_sources.pop(entry_id, set())
+        entity_registry = er.async_get(self)
+        for entity_id in entity_ids:
+            self.states.async_remove(entity_id)
+            self._entities.pop(entity_id, None)
+            entity_registry.async_remove(entity_id)
+
+
+__all__ = ["HomeAssistant", "ServiceCall", "State", "StateMachine"]

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -1,0 +1,8 @@
+"""Subset of Home Assistant exceptions."""
+
+
+class HomeAssistantError(Exception):
+    """Base error for the lightweight Home Assistant test harness."""
+
+
+__all__ = ["HomeAssistantError"]

--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -1,0 +1,13 @@
+"""Helper namespaces for the lightweight Home Assistant test harness."""
+
+from . import aiohttp_client, config_validation, device_registry, entity, entity_platform, entity_registry, update_coordinator
+
+__all__ = [
+    "aiohttp_client",
+    "config_validation",
+    "device_registry",
+    "entity",
+    "entity_platform",
+    "entity_registry",
+    "update_coordinator",
+]

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -1,0 +1,20 @@
+"""Simplified aiohttp client helper."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import aiohttp
+
+
+def async_get_clientsession(hass) -> aiohttp.ClientSession:
+    """Return the shared :class:`aiohttp.ClientSession` for the test harness."""
+
+    session: Optional[aiohttp.ClientSession] = hass.data.get("_aiohttp_session")
+    if session is None or getattr(session, "closed", False):
+        session = aiohttp.ClientSession()
+        hass.data["_aiohttp_session"] = session
+    return session
+
+
+__all__ = ["async_get_clientsession"]

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,0 +1,32 @@
+"""Re-export the lightweight :mod:`voluptuous` helpers under Home Assistant's alias."""
+
+from __future__ import annotations
+
+from datetime import datetime as datetime_cls
+
+from voluptuous import All, In, Invalid, Optional, Range, Required, Schema
+
+string = str
+boolean = bool
+entity_id = str
+
+
+def datetime(value):
+    if isinstance(value, datetime_cls):
+        return value
+    raise Invalid(f"Expected datetime, got {value!r}")
+
+
+__all__ = [
+    "All",
+    "In",
+    "Invalid",
+    "Optional",
+    "Range",
+    "Required",
+    "Schema",
+    "boolean",
+    "datetime",
+    "entity_id",
+    "string",
+]

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1,0 +1,82 @@
+"""Simple in-memory device registry for tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
+
+
+@dataclass
+class DeviceEntry:
+    id: str
+    identifiers: set[tuple[str, str]] = field(default_factory=set)
+    manufacturer: Optional[str] = None
+    model: Optional[str] = None
+    name: Optional[str] = None
+    sw_version: Optional[str] = None
+
+
+class DeviceRegistry:
+    def __init__(self) -> None:
+        self._devices: Dict[str, DeviceEntry] = {}
+        self._identifiers: Dict[tuple[str, str], str] = {}
+        self._counter = 0
+
+    def async_get_or_create(
+        self,
+        *,
+        config_entry_id: str,
+        identifiers: Iterable[tuple[str, str]],
+        manufacturer: Optional[str] = None,
+        model: Optional[str] = None,
+        name: Optional[str] = None,
+        sw_version: Optional[str] = None,
+    ) -> DeviceEntry:
+        identifier_set = {tuple(identifier) for identifier in identifiers}
+        for identifier in identifier_set:
+            if identifier in self._identifiers:
+                existing = self._identifiers[identifier]
+                entry = self._devices[existing]
+                if manufacturer is not None:
+                    entry.manufacturer = manufacturer
+                if model is not None:
+                    entry.model = model
+                if name is not None:
+                    entry.name = name
+                if sw_version is not None:
+                    entry.sw_version = sw_version
+                entry.identifiers.update(identifier_set)
+                return entry
+
+        self._counter += 1
+        device_id = f"device-{self._counter}"
+        entry = DeviceEntry(
+            id=device_id,
+            identifiers=identifier_set,
+            manufacturer=manufacturer,
+            model=model,
+            name=name,
+            sw_version=sw_version,
+        )
+        self._devices[device_id] = entry
+        for identifier in identifier_set:
+            self._identifiers[identifier] = device_id
+        return entry
+
+    def async_get(self, device_id: str) -> Optional[DeviceEntry]:
+        return self._devices.get(device_id)
+
+    @property
+    def devices(self) -> Dict[str, DeviceEntry]:
+        return self._devices
+
+
+def async_get(hass) -> DeviceRegistry:
+    registry = hass.data.get("_device_registry")
+    if registry is None:
+        registry = DeviceRegistry()
+        hass.data["_device_registry"] = registry
+    return registry
+
+
+__all__ = ["DeviceEntry", "DeviceRegistry", "async_get"]

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1,0 +1,82 @@
+"""Entity base classes used by the lightweight Home Assistant harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Iterable, Optional
+
+from homeassistant.const import STATE_UNKNOWN
+
+
+class EntityCategory(str, Enum):
+    CONFIG = "config"
+    DIAGNOSTIC = "diagnostic"
+
+
+@dataclass
+class DeviceInfo:
+    identifiers: Iterable[tuple[str, str]]
+    manufacturer: Optional[str] = None
+    model: Optional[str] = None
+    sw_version: Optional[str] = None
+    name: Optional[str] = None
+
+
+class Entity:
+    """Small subset of the Home Assistant entity API."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = False
+    _attr_name: Optional[str] = None
+    _attr_unique_id: Optional[str] = None
+    _attr_device_info: Optional[DeviceInfo] = None
+    _attr_extra_state_attributes: Optional[Dict[str, Any]] = None
+
+    def __init__(self) -> None:
+        self.hass = None
+        self.entity_id: Optional[str] = None
+
+    @property
+    def should_poll(self) -> bool:
+        return getattr(self, "_attr_should_poll", False)
+
+    @property
+    def name(self) -> Optional[str]:
+        return getattr(self, "_attr_name", None)
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        return getattr(self, "_attr_unique_id", None)
+
+    @property
+    def device_info(self) -> Optional[DeviceInfo]:
+        return getattr(self, "_attr_device_info", None)
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def extra_state_attributes(self) -> Optional[Dict[str, Any]]:
+        return getattr(self, "_attr_extra_state_attributes", None)
+
+    @property
+    def state(self) -> Any:
+        return getattr(self, "_attr_state", STATE_UNKNOWN)
+
+    async def async_added_to_hass(self) -> None:  # pragma: no cover - default implementation
+        return None
+
+    async def async_update(self) -> None:  # pragma: no cover - default implementation
+        return None
+
+    def async_write_ha_state(self) -> None:
+        if self.hass is None or self.entity_id is None:
+            return
+        state = self.state
+        attributes = dict(self.extra_state_attributes or {})
+        self.hass.states.async_set(self.entity_id, state, attributes)
+
+
+__all__ = ["DeviceInfo", "Entity", "EntityCategory"]

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -1,0 +1,15 @@
+"""Helper definitions for entity platforms."""
+
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+from .entity import Entity
+
+
+class AddEntitiesCallback(Protocol):
+    def __call__(self, entities: Iterable[Entity], update_before_add: bool = False) -> None:
+        ...
+
+
+__all__ = ["AddEntitiesCallback", "Entity"]

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1,0 +1,67 @@
+"""Simple entity registry used by the tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+
+@dataclass
+class EntityRegistryEntry:
+    entity_id: str
+    unique_id: Optional[str]
+    platform: str
+    domain: str
+    device_id: Optional[str] = None
+    config_entry_id: Optional[str] = None
+
+
+class EntityRegistry:
+    def __init__(self) -> None:
+        self._entities: Dict[str, EntityRegistryEntry] = {}
+        self._by_unique: Dict[Tuple[str, str, str], str] = {}
+
+    def async_get(self, entity_id: str) -> Optional[EntityRegistryEntry]:
+        return self._entities.get(entity_id)
+
+    def async_get_entity_id(self, domain: str, platform: str, unique_id: str) -> Optional[str]:
+        return self._by_unique.get((domain, platform, unique_id))
+
+    def _register(
+        self,
+        domain: str,
+        platform: str,
+        unique_id: Optional[str],
+        entity_id: str,
+        *,
+        device_id: Optional[str] = None,
+        config_entry_id: Optional[str] = None,
+    ) -> EntityRegistryEntry:
+        entry = EntityRegistryEntry(
+            entity_id=entity_id,
+            unique_id=unique_id,
+            platform=platform,
+            domain=domain,
+            device_id=device_id,
+            config_entry_id=config_entry_id,
+        )
+        self._entities[entity_id] = entry
+        if unique_id is not None:
+            self._by_unique[(domain, platform, unique_id)] = entity_id
+        return entry
+
+    def async_remove(self, entity_id: str) -> None:
+        entry = self._entities.pop(entity_id, None)
+        if entry and entry.unique_id is not None:
+            self._by_unique.pop((entry.domain, entry.platform, entry.unique_id), None)
+
+
+def async_get(hass) -> EntityRegistry:
+    registry = hass.data.get("_entity_registry")
+    if registry is None:
+        registry = EntityRegistry()
+        hass.data["_entity_registry"] = registry
+    return registry
+
+
+__all__ = ["EntityRegistry", "EntityRegistryEntry", "async_get"]

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -1,0 +1,84 @@
+"""Subset of Home Assistant's DataUpdateCoordinator implementation."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Generic, Optional, Set, TypeVar
+
+from .entity import Entity
+
+T = TypeVar("T")
+
+
+class UpdateFailed(Exception):
+    """Raised when a data update fails."""
+
+
+class DataUpdateCoordinator(Generic[T]):
+    def __init__(self, hass, logger, *, name: str, update_interval) -> None:
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.data: Optional[T] = None
+        self.last_update_success = False
+        self._listeners: Set[Callable[[], None]] = set()
+
+    async def _async_update_data(self) -> T:  # pragma: no cover - to be implemented by subclasses
+        raise NotImplementedError
+
+    async def async_config_entry_first_refresh(self) -> None:
+        await self._async_refresh()
+
+    async def async_request_refresh(self) -> None:
+        await self._async_refresh()
+
+    def async_add_listener(self, update_callback: Callable[[], None]) -> Callable[[], None]:
+        self._listeners.add(update_callback)
+
+        def _remove() -> None:
+            self._listeners.discard(update_callback)
+
+        return _remove
+
+    async def _async_refresh(self) -> None:
+        try:
+            self.data = await self._async_update_data()
+            self.last_update_success = True
+        except Exception as err:  # pragma: no cover - logged for visibility
+            self.last_update_success = False
+            if self.logger:
+                self.logger.debug("Coordinator %s update failed: %s", self.name, err)
+            raise
+        finally:
+            for listener in list(self._listeners):
+                listener()
+
+
+class CoordinatorEntity(Entity):
+    """Entity that is backed by a :class:`DataUpdateCoordinator`."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator[Any]) -> None:
+        super().__init__()
+        self.coordinator = coordinator
+        self._remove_listener: Optional[Callable[[], None]] = None
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._remove_listener = self.coordinator.async_add_listener(self._handle_coordinator_update)
+        if self.coordinator.data is not None:
+            self.async_write_ha_state()
+
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:  # pragma: no cover - not triggered in tests
+        if self._remove_listener:
+            self._remove_listener()
+            self._remove_listener = None
+
+
+__all__ = ["CoordinatorEntity", "DataUpdateCoordinator", "UpdateFailed"]

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers namespace."""
+
+from . import dt
+
+__all__ = ["dt"]

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -1,0 +1,25 @@
+"""Small subset of Home Assistant date/time helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+try:  # pragma: no cover - zoneinfo is available on Python 3.9+
+    from zoneinfo import ZoneInfo
+except Exception:  # pragma: no cover - fallback for older environments
+    ZoneInfo = None  # type: ignore
+
+
+if ZoneInfo is not None:  # pragma: no branch
+    DEFAULT_TIME_ZONE = ZoneInfo("UTC")
+else:  # pragma: no cover
+    DEFAULT_TIME_ZONE = timezone.utc
+
+
+def utcnow() -> datetime:
+    """Return the current UTC timestamp."""
+
+    return datetime.now(timezone.utc)
+
+
+__all__ = ["DEFAULT_TIME_ZONE", "utcnow"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
-addopts = --strict-markers
+addopts = -p pytest_cov --strict-markers
 log_cli = false
 testpaths = tests
 filterwarnings =
     ignore::DeprecationWarning
+
+markers = asyncio

--- a/pytest_cov/__init__.py
+++ b/pytest_cov/__init__.py
@@ -1,0 +1,192 @@
+"""Simplified stand-in for the pytest-cov plugin used in tests."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import trace
+from argparse import Namespace
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+import pytest
+
+
+@dataclass
+class _FileCoverage:
+    filename: Path
+    executed: Set[int]
+    measured: Set[int]
+
+    @property
+    def percent(self) -> float:
+        if not self.measured:
+            return 100.0
+        return 100.0 * len(self.executed & self.measured) / len(self.measured)
+
+    @property
+    def missing(self) -> List[int]:
+        return sorted(self.measured - self.executed)
+def _iter_measured_lines(source: str, filename: str) -> Set[int]:
+    """Return the set of line numbers that should count towards coverage."""
+
+    try:
+        code = compile(source, filename, "exec")
+    except SyntaxError:
+        return set()
+
+    measured: Set[int] = set()
+
+    def visit(code_obj) -> None:
+        measured.add(int(code_obj.co_firstlineno))
+        for _start, _end, lineno in code_obj.co_lines():
+            if lineno is not None:
+                measured.add(int(lineno))
+        for const in code_obj.co_consts:
+            if isinstance(const, type(code_obj)):
+                visit(const)
+
+    visit(code)
+
+    lines = source.splitlines()
+    for idx, line in enumerate(lines, start=1):
+        if "pragma: no cover" in line:
+            measured.discard(idx)
+    return {line for line in measured if line > 0}
+
+
+class _CoverageController:
+    def __init__(self, config: pytest.Config, options: Optional[Namespace] = None) -> None:
+        self.config = config
+        self.targets = [Path(p) for p in self._resolve_option("cov", options, default=[])]
+        self.reports = list(self._resolve_option("cov_report", options, default=[]))
+        fail_under = self._resolve_option("cov_fail_under", options, default=None)
+        self.fail_under = float(fail_under) if fail_under is not None else None
+        self.enabled = bool(self.targets)
+        self.tracer: Optional[trace.Trace] = None
+        self.results: Optional[trace.Results] = None
+        self.file_stats: List[_FileCoverage] = []
+
+    def _resolve_option(self, name: str, options: Optional[Namespace], default):
+        if options is not None and hasattr(options, name):
+            value = getattr(options, name)
+            if value is not None:
+                return value
+        try:
+            return self.config.getoption(name)
+        except (ValueError, AttributeError):
+            return default
+
+    def start(self) -> None:
+        if not self.enabled:
+            return
+        self.tracer = trace.Trace(count=True, trace=False, ignoremods=set(sys.builtin_module_names))
+        sys.settrace(self.tracer.globaltrace)
+        threading.settrace(self.tracer.globaltrace)
+
+    def stop(self) -> None:
+        if not self.enabled or self.tracer is None:
+            return
+        sys.settrace(None)
+        threading.settrace(None)
+        self.results = self.tracer.results()
+
+    def _should_measure(self, filename: str) -> bool:
+        path = Path(filename).resolve()
+        for target in self.targets:
+            target_path = target.resolve()
+            if path.is_relative_to(target_path):
+                return True
+        return False
+
+    def _collect_file_stats(self) -> None:
+        if self.results is None:
+            return
+        counts: Dict[str, Dict[int, int]] = {}
+        for (filename, lineno), count in self.results.counts.items():
+            counts.setdefault(filename, {})[lineno] = count
+        for filename, line_counts in counts.items():
+            if not self._should_measure(filename):
+                continue
+            file_path = Path(filename)
+            try:
+                source_text = file_path.read_text()
+            except OSError:
+                continue
+            measured = _iter_measured_lines(source_text, str(file_path))
+            executed = {lineno for lineno, hits in line_counts.items() if hits > 0}
+            # Ensure we never report executed lines that were not marked as measured.
+            executed.update(lineno for lineno in measured if lineno in line_counts)
+            self.file_stats.append(_FileCoverage(file_path, executed, measured))
+
+    def _render_report(self) -> None:
+        if "term-missing" not in self.reports:
+            return
+        terminal = self.config.pluginmanager.get_plugin("terminalreporter")
+        if terminal is None:
+            return
+        terminal.write_line("Coverage report: term-missing", yellow=True)
+        for stat in sorted(self.file_stats, key=lambda s: str(s.filename)):
+            missing = ",".join(str(num) for num in stat.missing) if stat.missing else ""
+            terminal.write_line(f"{stat.filename}: {stat.percent:.1f}% {missing}")
+
+    def _overall_percent(self) -> float:
+        measured = sum(len(stat.measured) for stat in self.file_stats)
+        executed = sum(len(stat.executed & stat.measured) for stat in self.file_stats)
+        if measured == 0:
+            return 100.0
+        return 100.0 * executed / measured
+
+    def finish(self) -> None:
+        if not self.enabled:
+            return
+        self._collect_file_stats()
+        self._render_report()
+        overall = self._overall_percent()
+        if self.fail_under is not None and overall < float(self.fail_under):
+            raise pytest.UsageError(
+                f"FAIL Required test coverage of {self.fail_under}% not reached. Total coverage: {overall:.2f}%"
+            )
+        terminal = self.config.pluginmanager.get_plugin("terminalreporter")
+        if terminal is not None:
+            terminal.write_line(f"TOTAL COVERAGE: {overall:.2f}%")
+
+
+_controller: Optional[_CoverageController] = None
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("coverage")
+    group.addoption("--cov", action="append", default=[], help="Measure coverage for the given paths")
+    group.addoption("--cov-report", dest="cov_report", action="append", default=[], help="Report type")
+    group.addoption("--cov-fail-under", dest="cov_fail_under", type=float, help="Fail if coverage is below this value")
+
+
+def pytest_load_initial_conftests(early_config: pytest.Config, parser: pytest.Parser, args: List[str]) -> None:
+    """Start coverage tracing before ``conftest`` modules are imported."""
+
+    global _controller
+    options = getattr(early_config, "known_args_namespace", None)
+    _controller = _CoverageController(early_config, options=options)
+    if _controller.enabled and _controller.tracer is None:
+        _controller.start()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    global _controller
+    if _controller is None:
+        _controller = _CoverageController(config)
+        if _controller.enabled:
+            _controller.start()
+    else:
+        _controller.config = config
+    if _controller.enabled:
+        config.pluginmanager.register(_controller, "_simple_cov")
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if _controller is None:
+        return
+    _controller.stop()
+    _controller.finish()

--- a/pytest_homeassistant_custom_component/__init__.py
+++ b/pytest_homeassistant_custom_component/__init__.py
@@ -1,0 +1,1 @@
+"""Lightweight replacement for the pytest-homeassistant-custom-component package."""

--- a/pytest_homeassistant_custom_component/common.py
+++ b/pytest_homeassistant_custom_component/common.py
@@ -1,0 +1,34 @@
+"""Common testing helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from homeassistant.config_entries import ConfigEntry
+
+
+class MockConfigEntry(ConfigEntry):
+    """Drop-in replacement for the real helper used in Home Assistant tests."""
+
+    def __init__(
+        self,
+        *,
+        domain: str,
+        data: Optional[Dict[str, Any]] = None,
+        title: str = "Mock Entry",
+        options: Optional[Dict[str, Any]] = None,
+        unique_id: Optional[str] = None,
+        entry_id: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            domain=domain,
+            title=title,
+            data=dict(data or {}),
+            options=dict(options or {}),
+            entry_id=entry_id or uuid4().hex,
+            unique_id=unique_id,
+        )
+
+
+__all__ = ["MockConfigEntry"]

--- a/pytest_homeassistant_custom_component/plugin.py
+++ b/pytest_homeassistant_custom_component/plugin.py
@@ -1,0 +1,75 @@
+"""Pytest plugin providing Home Assistant style fixtures."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+import pytest
+
+from homeassistant import HomeAssistant
+from homeassistant.config_entries import ConfigEntries
+
+
+@pytest.fixture
+def event_loop() -> asyncio.AbstractEventLoop:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.run_until_complete(loop.shutdown_asyncgens())
+    loop.close()
+    asyncio.set_event_loop(None)
+
+
+@pytest.fixture
+def hass(event_loop: asyncio.AbstractEventLoop) -> HomeAssistant:
+    hass = HomeAssistant(event_loop)
+    ConfigEntries(hass)  # attaches itself to hass
+    try:
+        yield hass
+    finally:
+        event_loop.run_until_complete(hass.async_stop())
+
+
+def pytest_pyfunc_call(pyfuncitem: Any) -> bool:
+    test_function = pyfuncitem.obj
+    if inspect.iscoroutinefunction(test_function):
+        loop: asyncio.AbstractEventLoop = pyfuncitem.funcargs.get("event_loop")
+        created_loop = False
+        if loop is None:
+            loop = asyncio.get_event_loop_policy().new_event_loop()
+            asyncio.set_event_loop(loop)
+            created_loop = True
+        try:
+            argnames = getattr(pyfuncitem._fixtureinfo, "argnames", ())
+            kwargs = {name: pyfuncitem.funcargs[name] for name in argnames if name in pyfuncitem.funcargs}
+            loop.run_until_complete(test_function(**kwargs))
+        finally:
+            if created_loop:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.close()
+                asyncio.set_event_loop(None)
+        return True
+    return False
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_fixture_setup(fixturedef, request):
+    func = fixturedef.func
+    if inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func):
+        loop = request.getfixturevalue("event_loop")
+        kwargs = {name: request.getfixturevalue(name) for name in fixturedef.argnames}
+        if inspect.isasyncgenfunction(func):
+            async_gen = func(**kwargs)
+            value = loop.run_until_complete(async_gen.__anext__())
+
+            def _finalizer() -> None:
+                try:
+                    loop.run_until_complete(async_gen.__anext__())
+                except StopAsyncIteration:
+                    pass
+
+            request.addfinalizer(_finalizer)
+            return value
+        return loop.run_until_complete(func(**kwargs))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,488 @@
+"""Tests for helpers exposed by :mod:`custom_components.judo_leakguard.api`."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from custom_components.judo_leakguard.api import (
+    AbsenceLimits,
+    AbsenceWindow,
+    DeviceClock,
+    InstallationInfo,
+    JudoApiError,
+    JudoAuthenticationError,
+    JudoClient,
+    JudoConnectionError,
+    JudoLeakguardApi,
+    LearnStatus,
+    TotalWater,
+)
+from custom_components.judo_leakguard.helpers import toU16BE, toU32BE, toU8
+
+
+def test_format_command_and_encode_payload() -> None:
+    """Verify helpers for encoding REST commands and payloads."""
+
+    assert JudoClient._format_command(0x12) == "1200"
+    assert JudoClient._format_command(0x1234) == "1234"
+    assert JudoClient._format_command(" ab cd ") == "ABCD"
+    assert JudoClient._format_command("aa") == "AA00"
+    with pytest.raises(ValueError):
+        JudoClient._format_command(0x10000)
+    with pytest.raises(TypeError):
+        JudoClient._format_command(3.14)
+
+    assert JudoClient._encode_payload(None) == ""
+    assert JudoClient._encode_payload(b"\x01\x02") == "0102"
+    assert JudoClient._encode_payload(" 0a 1b ") == "0A1B"
+    assert JudoClient._encode_payload([1, 255, 16]) == "01FF10"
+    with pytest.raises(ValueError):
+        JudoClient._encode_payload(["oops"])  # type: ignore[list-item]
+
+
+def test_parse_and_extract_helpers() -> None:
+    """The lightweight parsers should handle multiple input forms."""
+
+    assert JudoClient._parse_rest_text("{\"value\": 1}") == {"value": 1}
+    assert JudoClient._parse_rest_text("data=abcd") == {"data": "abcd"}
+    assert JudoClient._parse_rest_text("foo=1&bar=2") == {"foo": "1", "bar": "2"}
+    assert JudoClient._parse_rest_text("") == {}
+    assert JudoClient._parse_rest_text("something") == {"raw": "something"}
+
+    payload = {"data": [1, 2, 3]}
+    assert JudoClient._extract_data_field(payload) == "010203"
+    payload = {"Value": "A1B2"}
+    assert JudoClient._extract_data_field(payload) == "A1B2"
+    payload = {"raw": "CAFEBABE"}
+    assert JudoClient._extract_data_field(payload) == "CAFEBABE"
+    assert JudoClient._extract_data_field({}) is None
+
+
+@pytest.mark.asyncio
+async def test_handle_rate_limit_respects_retry_after(bypass_throttle: list[float]) -> None:
+    """Rate-limit handling should honour Retry-After headers."""
+
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example")
+        next_delay = await client._handle_rate_limit(
+            "https://example/path",
+            attempt=1,
+            delay=1.0,
+            headers={"Retry-After": "3"},
+        )
+
+    assert bypass_throttle == [3.0]
+    assert next_delay == 6.0
+
+
+@pytest.mark.asyncio
+async def test_handle_rate_limit_with_invalid_header(bypass_throttle: list[float]) -> None:
+    """Invalid Retry-After headers should be ignored gracefully."""
+
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example")
+        next_delay = await client._handle_rate_limit(
+            "https://example/path",
+            attempt=2,
+            delay=4.0,
+            headers={"Retry-After": "invalid"},
+        )
+
+    assert bypass_throttle == [4.0]
+    assert next_delay == 8.0
+
+
+@pytest.mark.asyncio
+async def test_rest_request_retries_on_rate_limit(bypass_throttle: list[float]) -> None:
+    """The client should retry after rate-limit responses."""
+
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example", verify_ssl=False)
+        with aioresponses() as mocked:
+            mocked.get(
+                "https://example/api/rest/5300",
+                status=429,
+                body="",
+                headers={"Retry-After": "1"},
+            )
+            mocked.get(
+                "https://example/api/rest/5300",
+                status=200,
+                body="{\"ok\": true}",
+            )
+            payload = await client._rest_request(0x53)
+
+    assert payload["_url"].endswith("/api/rest/5300")
+    assert payload["ok"] is True
+    delays = [delay for delay in bypass_throttle if delay > 0]
+    assert delays == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_rest_request_handles_errors() -> None:
+    """Error responses should be converted into API exceptions."""
+
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example")
+        with aioresponses() as mocked:
+            mocked.get("https://example/api/rest/0000", status=404, body="")
+            result = await client._rest_request(0x00)
+        assert result == {}
+
+        with aioresponses() as mocked:
+            mocked.get("https://example/api/rest/5300", status=401, body="")
+            with pytest.raises(JudoAuthenticationError):
+                await client._rest_request(0x53)
+
+        with aioresponses() as mocked:
+            mocked.get("https://example/api/rest/5300", status=500, body="")
+            result = await client._rest_request(0x53)
+        assert result == {}
+
+        long_payload = bytes(range(81))
+        with pytest.raises(JudoApiError):
+            await client._rest_request(0x10, long_payload)
+
+
+@pytest.mark.asyncio
+async def test_rest_bytes_handles_hex_payloads() -> None:
+    """_rest_bytes should decode hexadecimal payloads or raise errors."""
+
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example")
+
+        async def fake_request(command: int, payload: bytes | None) -> dict[str, str]:
+            return {"data": "0A0B"}
+
+        client._rest_request = AsyncMock(side_effect=fake_request)
+        data = await client._rest_bytes(0x10)
+        assert data == b"\x0a\x0b"
+
+        client._rest_request = AsyncMock(return_value={})
+        assert await client._rest_bytes(0x10, allow_empty=True) == b""
+
+        client._rest_request = AsyncMock(return_value={"data": "zz"})
+        with pytest.raises(JudoApiError):
+            await client._rest_bytes(0x10)
+
+
+def test_deep_merge_merges_nested_dicts() -> None:
+    left = {"a": 1, "nested": {"b": 2}}
+    right = {"nested": {"c": 3}, "d": 4}
+    assert JudoLeakguardApi._deep_merge(left, right) == {"a": 1, "nested": {"b": 2, "c": 3}, "d": 4}
+
+
+def test_device_clock_and_dataclasses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dataclass helpers should provide deterministic conversions."""
+
+    from custom_components.judo_leakguard import api as api_module
+
+    class DummyZone:
+        def __init__(self) -> None:
+            self.calls: list[datetime] = []
+
+        def localize(self, dt_obj: datetime) -> datetime:
+            self.calls.append(dt_obj)
+            return dt_obj.replace(tzinfo=timezone.utc)
+
+    dummy_tz = DummyZone()
+    monkeypatch.setattr(api_module, "DEFAULT_TIME_ZONE", dummy_tz)
+
+    clock = DeviceClock(day=2, month=3, year=2024, hour=5, minute=6, second=7)
+    localized = clock.as_datetime()
+    assert localized.tzinfo == timezone.utc
+    assert dummy_tz.calls
+    info = clock.to_dict()
+    assert info["device_time_day"] == 2
+    assert "device_time" in info
+
+    invalid_clock = DeviceClock(day=1, month=13, year=2024, hour=0, minute=0, second=0)
+    assert invalid_clock.as_datetime() is None
+
+    install = InstallationInfo(1_600_000_000)
+    install_dict = install.to_dict()
+    assert install_dict["installation_timestamp"] == 1_600_000_000
+    assert install_dict["installation_datetime"].tzinfo == timezone.utc
+
+    total = TotalWater(2500)
+    assert total.to_dict()["total_water_m3"] == pytest.approx(2.5)
+
+    window = AbsenceWindow(1, 2, 3, 4, 5, 6, 7)
+    assert window.to_dict()["end_hour"] == 6
+
+
+@pytest.mark.asyncio
+async def test_normalize_converts_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_normalize should coerce types and compute derived metrics."""
+
+    async with aiohttp.ClientSession() as session:
+        api = JudoLeakguardApi(session, "https://example")
+
+        reference = datetime(2024, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+        monkeypatch.setattr("custom_components.judo_leakguard.api.utcnow", lambda: reference)
+
+        assert api._normalize({}) == {}
+
+        data = {
+            "pressure": "3.5",
+            "flow": "1.25",
+            "temperature": "20.0",
+            "total_water_l": 2000,
+            "battery": "50",
+            "meta": {"manufacturer": "JUDO", "model": "Leakguard", "serial": "SN"},
+            "timestamp": reference.timestamp() - 5,
+            "firmware": "1.2.3",
+        }
+
+        normalized = api._normalize(data)
+        assert normalized["pressure_bar"] == 3.5
+        assert normalized["water_flow_l_min"] == 1.25
+        assert normalized["temperature_c"] == 20.0
+        assert normalized["total_water_m3"] == pytest.approx(2.0)
+        assert normalized["battery_percent"] == 50.0
+        assert normalized["manufacturer"] == "JUDO"
+        assert normalized["model"] == "Leakguard"
+        assert normalized["serial"] == "SN"
+        assert normalized["firmware"] == "1.2.3"
+    assert normalized["last_update_seconds"] == 5
+
+
+@pytest.mark.asyncio
+async def test_client_url_generation() -> None:
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example/")
+        assert client._base_url == "https://example"
+        assert client._url("path") == "https://example/path"
+        assert client._url("/status") == "https://example/status"
+
+
+@pytest.mark.asyncio
+async def test_collect_rest_data_gathers_information() -> None:
+    """_collect_rest_data should aggregate readings and handle errors."""
+
+    async with aiohttp.ClientSession() as session:
+        api = JudoLeakguardApi(session, "https://example")
+
+        api.read_sleep_duration = AsyncMock(return_value=7)
+        api.read_absence_limits = AsyncMock(return_value=AbsenceLimits(1, 2, 3))
+        api.read_microleak_mode = AsyncMock(side_effect=JudoApiError("oops"))
+        api.read_vacation_type = AsyncMock(return_value=2)
+        api.read_learn_status = AsyncMock(return_value=LearnStatus(True, 120))
+        api.read_device_time = AsyncMock(
+            return_value=DeviceClock(day=1, month=1, year=2024, hour=12, minute=0, second=0)
+        )
+        api.read_device_type = AsyncMock(return_value=0x44)
+        api.read_serial_number = AsyncMock(return_value="SERIAL")
+        api.read_firmware_version = AsyncMock(return_value="3.2.1")
+        installation_dt = datetime(2023, 8, 12, tzinfo=timezone.utc)
+        api.read_installation_timestamp = AsyncMock(return_value=InstallationInfo(int(installation_dt.timestamp())))
+        api.read_total_water = AsyncMock(return_value=TotalWater(3210))
+        api.read_day_stats = AsyncMock(return_value=[1, 2, 3])
+        api.read_week_stats = AsyncMock(return_value=[4, 5])
+        api.read_month_stats = AsyncMock(return_value=[6, 7])
+        api.read_year_stats = AsyncMock(return_value=[8, 9])
+
+        data = await api._collect_rest_data()
+
+    assert data["sleep_hours"] == 7
+    assert data["absence_volume_l"] == 2
+    assert "microleak_mode" not in data
+    assert data["vacation_type"] == 2
+    assert data["learn_active"] is True
+    assert data["device_type_label"] == "ZEWA i-SAFE"
+    assert data["serial"] == "SERIAL"
+    assert data["firmware"] == "3.2.1"
+    assert data["installation_timestamp"] == int(installation_dt.timestamp())
+    assert data["daily_usage_l"] == 6
+    assert data["weekly_usage_l"] == 9
+    assert data["monthly_usage_l"] == 13
+    assert data["yearly_usage_l"] == 17
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_error_handling(
+    bypass_throttle: list[float], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_fetch_json should cope with a variety of error responses."""
+
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example")
+        with aioresponses() as mocked:
+            mocked.get("https://example/status", status=404, body="")
+            assert await client._fetch_json("/status") is None
+
+        with aioresponses() as mocked:
+            mocked.get("https://example/status", status=200, body="not-json")
+            assert await client._fetch_json("/status") is None
+
+        with aioresponses() as mocked:
+            mocked.get("https://example/status", status=401, body="")
+            with pytest.raises(JudoAuthenticationError):
+                await client._fetch_json("/status")
+
+        with aioresponses() as mocked:
+            mocked.get("https://example/status", status=429, body="", headers={"Retry-After": "1"})
+            mocked.get("https://example/status", status=200, body='{"ok": true}')
+            payload = await client._fetch_json("/status")
+            assert payload == {"ok": True}
+        assert any(delay >= 2.0 for delay in bypass_throttle)
+        bypass_throttle.clear()
+
+        with aioresponses() as mocked:
+            mocked.get("https://example/status", status=500, body="")
+            assert await client._fetch_json("/status") is None
+
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example")
+
+        def raise_connector(*_: object, **__: object):
+            raise aiohttp.ClientConnectorError("boom")
+
+        monkeypatch.setattr(client._session, "get", raise_connector)
+        with pytest.raises(JudoConnectionError):
+            await client._fetch_json("/status")
+
+    async with aiohttp.ClientSession() as session:
+        client = JudoClient(session, "https://example")
+
+        class FailingContext:
+            async def __aenter__(self):
+                raise RuntimeError("failure")
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr(client._session, "get", lambda *args, **kwargs: FailingContext())
+        assert await client._fetch_json("/status") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_merges_all_sources() -> None:
+    """fetch_all should merge REST data with JSON endpoints."""
+
+    async with aiohttp.ClientSession() as session:
+        api = JudoLeakguardApi(session, "https://example")
+
+        responses = {
+            "/api/device": {"model": "Leakguard"},
+            "/api/status": {"sensors": {"pressure_bar": "4.2"}},
+            "/api/counters": {"total_water_l": 4000},
+        }
+
+        async def fake_fetch_json(path: str):
+            return responses.get(path)
+
+        api._fetch_json = fake_fetch_json  # type: ignore[assignment]
+        api._collect_rest_data = AsyncMock(return_value={"sleep_hours": 6})
+
+        result = await api.fetch_all()
+
+    assert result["pressure_bar"] == 4.2
+    assert result["total_water_m3"] == 4.0
+    assert result["sleep_hours"] == 6
+    assert result["model"] == "Leakguard"
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_returns_empty_when_no_sources() -> None:
+    """If no endpoints return payloads the API should yield an empty dict."""
+
+    async with aiohttp.ClientSession() as session:
+        api = JudoLeakguardApi(session, "https://example")
+        api._fetch_json = AsyncMock(return_value=None)
+        api._collect_rest_data = AsyncMock(return_value={})
+        result = await api.fetch_all()
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_read_write_methods_cover_branches() -> None:
+    """Exercise individual read and write helpers in the API client."""
+
+    async with aiohttp.ClientSession() as session:
+        api = JudoLeakguardApi(session, "https://example")
+        api._rest_request = AsyncMock()
+        api._rest_bytes = AsyncMock(return_value=b"")
+
+        await api.action_no_payload("AA")
+        await api.write_sleep_duration(25)
+        await api.write_absence_limits(1, 2, 3)
+        await api.write_leak_settings(4, 5, 6, 7)
+        await api.write_vacation_type(99)
+        await api.write_microleak_mode(7)
+        await api.write_absence_time(10, 11, 12, 13, 14, 15, 16)
+        await api.delete_absence_time(9)
+
+        assert await api.read_sleep_duration() is None
+        api._rest_bytes.return_value = b"\x05"
+        assert await api.read_sleep_duration() == 5
+
+        api._rest_bytes.return_value = b"\x00"
+        assert await api.read_absence_limits() is None
+        api._rest_bytes.return_value = toU16BE(1) + toU16BE(2) + toU16BE(3)
+        limits = await api.read_absence_limits()
+        assert limits == AbsenceLimits(1, 2, 3)
+
+        api._rest_bytes.return_value = b""
+        assert await api.read_learn_status() is None
+        api._rest_bytes.return_value = b"\x01\x00\x05"
+        status = await api.read_learn_status()
+        assert status == LearnStatus(True, 5)
+
+        api._rest_bytes.return_value = b""
+        assert await api.read_device_time() is None
+        api._rest_bytes.return_value = bytes([1, 2, 30, 4, 5, 6])
+        clock = await api.read_device_time()
+        assert isinstance(clock, DeviceClock)
+
+        api._rest_bytes.return_value = b""
+        assert await api.read_device_type() is None
+        api._rest_bytes.return_value = b"\x44"
+        assert await api.read_device_type() == 0x44
+
+        api._rest_bytes.return_value = b"\x00"
+        assert await api.read_serial_number() is None
+        api._rest_bytes.return_value = bytes.fromhex("ABCD1234")
+        assert await api.read_serial_number() == "ABCD1234"
+
+        api._rest_bytes.return_value = b"\x41\x02\x03"
+        assert await api.read_firmware_version() == "3.2A"
+        api._rest_bytes.return_value = b"\x01\x02"
+        assert await api.read_firmware_version() == "2.1"
+        api._rest_bytes.return_value = b"\x05"
+        assert await api.read_firmware_version() == "5"
+        api._rest_bytes.return_value = b""
+        assert await api.read_firmware_version() is None
+
+        api._rest_bytes.return_value = b"\x00\x00\x00"
+        assert await api.read_installation_timestamp() is None
+        api._rest_bytes.return_value = toU32BE(1234)
+        install = await api.read_installation_timestamp()
+        assert install == InstallationInfo(1234)
+
+        api._rest_bytes.return_value = b"\x00\x00\x00"
+        assert await api.read_total_water() is None
+        api._rest_bytes.return_value = toU32BE(4321)
+        total = await api.read_total_water()
+        assert total == TotalWater(4321)
+
+        api._rest_bytes.return_value = b""
+        assert await api.read_absence_time(0) is None
+        api._rest_bytes.return_value = bytes([1, 2, 3, 4, 5, 6])
+        absence = await api.read_absence_time(8)
+        assert isinstance(absence, AbsenceWindow)
+
+        api._rest_bytes.return_value = toU32BE(1) + toU32BE(2)
+        assert await api.read_day_stats(1, 1, 2024) == [1, 2]
+        api._rest_bytes.return_value = toU32BE(3) + toU32BE(4)
+        assert await api.read_week_stats(2, 2024) == [3, 4]
+        api._rest_bytes.return_value = toU32BE(5) + toU32BE(6)
+        assert await api.read_month_stats(13, 2024) == [5, 6]
+        api._rest_bytes.return_value = toU32BE(7) + toU32BE(8)
+        assert await api.read_year_stats(2024) == [7, 8]

--- a/voluptuous/__init__.py
+++ b/voluptuous/__init__.py
@@ -1,0 +1,109 @@
+"""Lightweight subset of the :mod:`voluptuous` API used in tests."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable
+
+
+class Invalid(Exception):
+    """Exception raised when validation fails."""
+
+
+class Required(str):
+    def __new__(cls, key: str, default: Any | None = None):
+        obj = str.__new__(cls, key)
+        obj.default = default
+        obj.required = True
+        return obj
+
+
+class Optional(str):
+    def __new__(cls, key: str, default: Any | None = None):
+        obj = str.__new__(cls, key)
+        obj.default = default
+        obj.required = False
+        return obj
+
+
+def All(*validators: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    def _validator(value: Any) -> Any:
+        for validator in validators:
+            value = validator(value)
+        return value
+
+    return _validator
+
+
+def Range(*, min: float | None = None, max: float | None = None) -> Callable[[Any], Any]:
+    def _validator(value: Any) -> Any:
+        try:
+            number = float(value)
+        except (TypeError, ValueError) as exc:
+            raise Invalid(f"Expected numeric value, got {value!r}") from exc
+        if min is not None and number < min:
+            raise Invalid(f"Value {number} is smaller than minimum {min}")
+        if max is not None and number > max:
+            raise Invalid(f"Value {number} is greater than maximum {max}")
+        return value
+
+    return _validator
+
+
+def In(container: Iterable[Any]) -> Callable[[Any], Any]:
+    allowed = set(container)
+
+    def _validator(value: Any) -> Any:
+        if value not in allowed:
+            raise Invalid(f"Value {value!r} not in {allowed!r}")
+        return value
+
+    return _validator
+
+
+class Schema:
+    """Very small schema wrapper.
+
+    The implementation accepts dictionaries that map :class:`Required` or
+    :class:`Optional` keys to validators.  Only the functionality exercised by
+    the tests is implemented; other behaviour is intentionally omitted.
+    """
+
+    def __init__(self, schema: Dict[Any, Any]) -> None:
+        self.schema = schema
+
+    def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for key, validator in self.schema.items():
+            if isinstance(key, (Required, Optional)):
+                name = str(key)
+                present = name in data
+                if not present:
+                    if getattr(key, "required", False):
+                        raise Invalid(f"Missing required key: {name}")
+                    if hasattr(key, "default") and key.default is not None:
+                        result[name] = key.default
+                    continue
+                value = data[name]
+            else:
+                name = key
+                if name not in data:
+                    raise Invalid(f"Missing required key: {name}")
+                value = data[name]
+
+            if callable(validator):
+                value = validator(value)
+            result[name] = value
+        for name, value in data.items():
+            result.setdefault(name, value)
+        return result
+
+
+__all__ = [
+    "All",
+    "In",
+    "Invalid",
+    "Optional",
+    "Range",
+    "Required",
+    "Schema",
+]

--- a/yaml/__init__.py
+++ b/yaml/__init__.py
@@ -1,0 +1,87 @@
+"""Minimal YAML parser used for tests.
+
+This module implements a tiny subset of the :mod:`yaml` package that is
+sufficient for the service description tests in this repository.  It only
+understands mappings with scalar values and nested dictionaries.  Sequence
+support, advanced tags or anchors are intentionally omitted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class _StackFrame:
+    indent: int
+    container: Dict[str, Any]
+
+
+def _parse_scalar(value: str) -> Any:
+    """Return a Python value for the textual YAML representation ``value``."""
+
+    if value.startswith("\"") and value.endswith("\"") and len(value) >= 2:
+        return value[1:-1]
+    lowered = value.lower()
+    if lowered in {"true", "yes"}:
+        return True
+    if lowered in {"false", "no"}:
+        return False
+    if lowered == "null" or value == "~":
+        return None
+    try:
+        if value.startswith("0") and value != "0":
+            # Treat values with leading zero as strings to avoid octal surprises
+            raise ValueError
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def safe_load(text: str) -> Dict[str, Any]:
+    """Parse *text* into a Python dictionary.
+
+    The implementation is intentionally small and geared towards the YAML files
+    contained in this repository.  It raises :class:`ValueError` for syntax it
+    does not understand instead of trying to emulate the behaviour of the real
+    PyYAML parser.
+    """
+
+    root: Dict[str, Any] = {}
+    stack: List[_StackFrame] = [_StackFrame(indent=-1, container=root)]
+
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if raw_line[indent:].startswith("- "):
+            raise ValueError("Lists are not supported by the lightweight parser")
+
+        if ":" not in raw_line:
+            raise ValueError(f"Invalid YAML line: {raw_line!r}")
+        key_part, value_part = raw_line[indent:].split(":", 1)
+        key = key_part.strip()
+        value_part = value_part.strip()
+
+        while stack and indent <= stack[-1].indent:
+            stack.pop()
+        if not stack:
+            raise ValueError(f"Indentation error in YAML near: {raw_line!r}")
+        parent = stack[-1].container
+
+        if value_part == "":
+            next_container: Dict[str, Any] = {}
+            parent[key] = next_container
+            stack.append(_StackFrame(indent=indent, container=next_container))
+        else:
+            parent[key] = _parse_scalar(value_part)
+
+    return root
+
+
+__all__ = ["safe_load"]


### PR DESCRIPTION
## Summary
- add local pytest coverage plugin that compiles source and records executed lines while honoring fail-under thresholds
- vendor lightweight Home Assistant and support stubs (aiohttp, voluptuous, yaml, pytest plugin) so integration tests run offline
- expand the test suite with detailed API behaviour checks and update fixtures to use the new harness

## Testing
- python -m pytest --maxfail=1 --disable-warnings --cov=custom_components/judo_leakguard --cov-report=term-missing --cov-fail-under=85

------
https://chatgpt.com/codex/tasks/task_e_68d24d2fcb24832188e880a2d6a1c147