### PR TITLE
Fix ruff warnings

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -6,8 +6,12 @@ import asyncio
 import inspect
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    from .core import HomeAssistant
+
 
 HANDLERS: Dict[str, type["ConfigFlow"]] = {}
 
@@ -114,13 +118,13 @@ class ConfigEntry:
         self.hass = None
         self.state = ConfigEntryState.NOT_LOADED
         self._on_unload: List[Callable[[], Any]] = []
-        self._update_listeners: List[Callable[["HomeAssistant", "ConfigEntry"], Any]] = []
+        self._update_listeners: List[Callable[[HomeAssistant, ConfigEntry], Any]] = []
 
-    def add_to_hass(self, hass: "HomeAssistant") -> None:
+    def add_to_hass(self, hass: HomeAssistant) -> None:
         self.hass = hass
         hass.config_entries._add(self)
 
-    def add_update_listener(self, listener: Callable[["HomeAssistant", "ConfigEntry"], Any]) -> Callable[[], None]:
+    def add_update_listener(self, listener: Callable[[HomeAssistant, ConfigEntry], Any]) -> Callable[[], None]:
         self._update_listeners.append(listener)
 
         def _remove() -> None:
@@ -140,7 +144,7 @@ class ConfigEntry:
 
 
 class ConfigEntriesFlowManager:
-    def __init__(self, hass: "HomeAssistant") -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         self.hass = hass
         self._flows: Dict[str, Dict[str, Any]] = {}
 
@@ -184,7 +188,7 @@ class ConfigEntriesFlowManager:
 
 
 class ConfigEntries:
-    def __init__(self, hass: "HomeAssistant") -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         self.hass = hass
         self._entries: Dict[str, ConfigEntry] = {}
         self.flow = ConfigEntriesFlowManager(hass)

--- a/pytest_cov/__init__.py
+++ b/pytest_cov/__init__.py
@@ -8,7 +8,7 @@ import trace
 from argparse import Namespace
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 import pytest
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ from custom_components.judo_leakguard.api import (
     LearnStatus,
     TotalWater,
 )
-from custom_components.judo_leakguard.helpers import toU16BE, toU32BE, toU8
+from custom_components.judo_leakguard.helpers import toU16BE, toU32BE
 
 
 def test_format_command_and_encode_payload() -> None:


### PR DESCRIPTION
## Summary
- import the HomeAssistant type for config entry helpers without introducing runtime cycles
- drop unused imports that ruff reported in the pytest_cov shim and API tests

## Testing
- if python -c "import importlib; importlib.import_module('ruff')" 2>/dev/null; then ruff check .; else echo "ruff not installed, skipping"; fi
- pytest *(fails: missing optional dependency `pytest_cov`)*

------
https://chatgpt.com/codex/tasks/task_e_68d26d0d31e4832181c87270300a9e14