### PR TITLE
Disable pytest_aiohttp autoload in pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 minversion = 8.0
 addopts =
+    -p no:pytest_aiohttp
     -ra
     --strict-markers
     --disable-warnings


### PR DESCRIPTION
## Summary
- prevent pytest from autoloading the pytest_aiohttp plugin so that the local aiohttp test stub no longer breaks the test run

## Testing
- not run (network-restricted environment prevents installing pytest dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d3934c516483219de47af237e5c84e